### PR TITLE
Fix 64-bit Android ABIs & allow manual ABI selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Build secp256k1.
 ``` bash
 # Android
 $ ./tools/build_android.sh
+# Alternatively you can specify the ABI to build:
+$ ARCHS=arm64-v8a ./tools/build_android.sh
+# all, armeabi-v7a, arm64-v8a, x86 or x86_64 are supported
 
 # iOS
 $ PLATFORM_NAME=iphoneos CONFIGURATION=debug ARCHS=arm64 ./tools/build_ios.sh

--- a/contrib/bitcoin-core/CMakeLists.txt
+++ b/contrib/bitcoin-core/CMakeLists.txt
@@ -89,7 +89,14 @@ add_library(${PROJECT_NAME} STATIC
 if (NOT ${USE_EXTERNAL_SECP256K1})
   if (ANDROID)
     add_library(libsecp256k1 STATIC IMPORTED)
-    set_target_properties(libsecp256k1 PROPERTIES IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/src/secp256k1/build/android/${ANDROID_ABI}/lib/libsecp256k1.a)
+
+    # Ensure we use the lib folder for 32-bit and lib64 folder for 64-bit
+    if (${CMAKE_ANDROID_ARCH} MATCHES "^(arm|mips|x86)$")
+      set_target_properties(libsecp256k1 PROPERTIES IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/src/secp256k1/build/android/${ANDROID_ABI}/lib/libsecp256k1.a)
+    else()
+      set_target_properties(libsecp256k1 PROPERTIES IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/src/secp256k1/build/android/${ANDROID_ABI}/lib64/libsecp256k1.a)
+    endif()
+    
     set_target_properties(libsecp256k1 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/src/secp256k1/include)
   elseif(IOS)
     add_library(libsecp256k1 STATIC IMPORTED)

--- a/tools/build_android.sh
+++ b/tools/build_android.sh
@@ -69,7 +69,7 @@ build()
 build armeabi-v7a armv7a-linux-androideabi
 build arm64-v8a   aarch64-linux-android
 build x86         i686-linux-android
-build x86-64      x86_64-linux-android
+build x86_64      x86_64-linux-android
 
 make clean
 


### PR DESCRIPTION
Hi, I'm submitting fixes for the supported 64-bit ABIs (arm64-v8a & x86_64), details of which can be found in f173e63c2356fd0cabbaf3ea3abfdf8840b09088. Additionally I added a feature where you can manually specify the ABI to build for secp256 on Android, 20400fa1da1b3851aadfeab31103505372968593.

This PR also fixes https://github.com/nunchuk-io/tap-protocol/issues/2