### PR TITLE
Fix libsecp256 not building for 64-bit Android on macOS

### DIFF
--- a/contrib/bitcoin-core/CMakeLists.txt
+++ b/contrib/bitcoin-core/CMakeLists.txt
@@ -91,7 +91,8 @@ if (NOT ${USE_EXTERNAL_SECP256K1})
     add_library(libsecp256k1 STATIC IMPORTED)
 
     # Ensure we use the lib folder for 32-bit and lib64 folder for 64-bit
-    if (${CMAKE_ANDROID_ARCH} MATCHES "^(arm|mips|x86)$")
+    # Note: macOS always outputs to a "lib" folder
+    if ((${CMAKE_ANDROID_ARCH} MATCHES "^(arm|mips|x86)$") OR (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin"))
       set_target_properties(libsecp256k1 PROPERTIES IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/src/secp256k1/build/android/${ANDROID_ABI}/lib/libsecp256k1.a)
     else()
       set_target_properties(libsecp256k1 PROPERTIES IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/src/secp256k1/build/android/${ANDROID_ABI}/lib64/libsecp256k1.a)


### PR DESCRIPTION
Sorry about this, my previous PR (https://github.com/nunchuk-io/tap-protocol/pull/3) to fix 64-bit Android builds failing due to the path for the secp256 library broke macOS. On my Mac the libraries are always created under a "lib" folder, never a "lib64" folder. With this change both Linux and macOS should work when targeting Android.