### PR TITLE
Use symlinks to avoid lib/lib64 Linux issue

### DIFF
--- a/contrib/bitcoin-core/CMakeLists.txt
+++ b/contrib/bitcoin-core/CMakeLists.txt
@@ -89,15 +89,7 @@ add_library(${PROJECT_NAME} STATIC
 if (NOT ${USE_EXTERNAL_SECP256K1})
   if (ANDROID)
     add_library(libsecp256k1 STATIC IMPORTED)
-
-    # Ensure we use the lib folder for 32-bit and lib64 folder for 64-bit
-    # Note: macOS always outputs to a "lib" folder
-    if ((${CMAKE_ANDROID_ARCH} MATCHES "^(arm|mips|x86)$") OR (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin"))
-      set_target_properties(libsecp256k1 PROPERTIES IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/src/secp256k1/build/android/${ANDROID_ABI}/lib/libsecp256k1.a)
-    else()
-      set_target_properties(libsecp256k1 PROPERTIES IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/src/secp256k1/build/android/${ANDROID_ABI}/lib64/libsecp256k1.a)
-    endif()
-    
+    set_target_properties(libsecp256k1 PROPERTIES IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/src/secp256k1/build/android/${ANDROID_ABI}/lib/libsecp256k1.a)
     set_target_properties(libsecp256k1 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/src/secp256k1/include)
   elseif(IOS)
     add_library(libsecp256k1 STATIC IMPORTED)

--- a/tools/build_android.sh
+++ b/tools/build_android.sh
@@ -70,7 +70,8 @@ build()
   export RANLIB=$TOOLCHAIN/bin/$TARGET-ranlib
   export STRIP=$TOOLCHAIN/bin/$TARGET-strip
 
-  ./configure --prefix="$pwd/build/android/$abi" --host=$TARGET $asm --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --enable-module-schnorrsig --enable-module-ecdh --enable-experimental --enable-tests=no
+  prefix="$pwd/build/android/$abi"
+  ./configure --prefix="$prefix" --host=$TARGET $asm --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --enable-module-schnorrsig --enable-module-ecdh --enable-experimental --enable-tests=no
 
   local num_jobs=4
   if [ -f /proc/cpuinfo ]; then
@@ -80,6 +81,15 @@ build()
   make clean
   make -j $num_jobs
   make install
+
+  # Some Linux distros output to a lib64 folder for some ABIs instead of lib
+  libName="libsecp256k1.a"
+  lib32Path="$prefix/lib"
+  lib64Path="$prefix/lib64"
+  if [ -f "$lib64Path/$libName" ] && [ ! -f "$lib32Path/$libName" ]; then
+    mkdir -p "$lib32Path"
+    ln -s "$lib64Path/$libName" "$lib32Path/$libName"
+  fi
 }
 
 if [[ $abiToBuild == "all" ]] || [[ $abiToBuild == "armeabi-v7a" ]]; then


### PR DESCRIPTION
I have to apologise again, my previous issue where compiling the Android libraries on Linux was failing due to some libraries being placed in a "lib64" path turned out to be distro-dependent. On some distros the files get placed into a "lib" path as was initially expected by the library. Due to this I reverted my previous changes and added a workaround using symlinks to make sure that if secp256k1 gets placed in a "lib64" path it will symlink to "lib" so CMake will always find it. Without directly integrating secp256k1 into CMake I don't think there's a better solution to this awkward problem. 

You can see I have the library building on Mac and Ubuntu via GitHub Actions: https://github.com/PeteClubSeven/cktap-protocol-flutter/actions/runs/7160231009